### PR TITLE
Remove Brad Childs from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - childsb
   - saad-ali


### PR DESCRIPTION
This PR removes Brad Childs' github ID from the OWNERS files where it appears.

Associated with kubernetes/community#4418

/assign @msau42 

CC @pmorie